### PR TITLE
jpg_ssim_test: modify ssim_test.py for jpeg testing

### DIFF
--- a/testscripts/ssim_test.py
+++ b/testscripts/ssim_test.py
@@ -57,7 +57,10 @@ def getYuvFile(src):
     return files[0]
 
 def getFileInfo(file):
-    m=re.search("(?P<width>\d+)x(?P<height>\d+)", file);
+    posEnd = file.rfind(".")
+    posStart = file.rfind("_")
+    resolution = file[posStart:posEnd]
+    m=re.search("(?P<width>\d+)x(?P<height>\d+)", resolution);
     w = int(m.group("width"))
     h = int(m.group("height"))
     if w == 0 or h == 0:
@@ -88,6 +91,7 @@ def verify(yuv, f, log):
 
 def test(f, log = False):
     if not testYami(f, log):
+        print(f + " failed")
         return False
 
     yuv = getYuvFile(f);


### PR DESCRIPTION
1, When decoding jpeg fails, print the faied file name on the log.
2, Split the resolution string part in case some file names contain 'x'.

Signed-off-by: dongping wu <dongpingx.wu@intel.com>