### PR TITLE
test/yamitranscode: fix decode output file format is always I420.

### DIFF
--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -395,7 +395,7 @@ public:
             return false;
         }
         m_input = createInput(m_cmdParam, m_display);
-        m_output = createOutput(m_cmdParam, m_display, m_input->getFourcc());
+        m_output = createOutput(m_cmdParam, m_display, m_cmdParam.fourcc);
         if (!m_input || !m_output) {
             ERROR("create input or output failed");
             return false;


### PR DESCRIPTION
Use specific fourcc format or format resolved from output file
to create vpp output in yamitranscode.

Signed-off-by: Wang,Fei <fei.w.wang@intel.com>