### PR TITLE
decode avformat: av_register_all is deprecated since 58.9.100

### DIFF
--- a/tests/decodeinputavformat.cpp
+++ b/tests/decodeinputavformat.cpp
@@ -29,7 +29,9 @@
 DecodeInputAvFormat::DecodeInputAvFormat()
 :m_format(NULL),m_videoId(-1), m_codecId(AV_CODEC_ID_NONE), m_isEos(true)
 {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
     av_register_all();
+#endif
 
     av_init_packet(&m_packet);
 }


### PR DESCRIPTION
av_register_all was deprecated in FFMPEG commit
0694d8702421e7aff1340038559c438b61bb30dd

It is no longer necessary to call av_register_all after
this commit.

Fixes #117

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>