### PR TITLE
Revert "decode avformat: av_register_all is deprecated since 58.9.100"

### DIFF
--- a/tests/decodeinputavformat.cpp
+++ b/tests/decodeinputavformat.cpp
@@ -29,9 +29,7 @@
 DecodeInputAvFormat::DecodeInputAvFormat()
 :m_format(NULL),m_videoId(-1), m_codecId(AV_CODEC_ID_NONE), m_isEos(true)
 {
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
     av_register_all();
-#endif
 
     av_init_packet(&m_packet);
 }


### PR DESCRIPTION
Reverts intel/libyami-utils#118

Forgot to push local update before
submitting pull-request.