### PR TITLE
decode avformat: use LIBAVFORMAT_VERSION_INT instead

### DIFF
--- a/tests/decodeinputavformat.cpp
+++ b/tests/decodeinputavformat.cpp
@@ -29,7 +29,7 @@
 DecodeInputAvFormat::DecodeInputAvFormat()
 :m_format(NULL),m_videoId(-1), m_codecId(AV_CODEC_ID_NONE), m_isEos(true)
 {
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 9, 100)
     av_register_all();
 #endif
 


### PR DESCRIPTION
LIBAVFORMAT_VERSION_INT should be checked instead of
LIBAVCODEC_VERSION_INT for av_register_all deprecation
since versions could differ.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>