### PR TITLE
Fix low latency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,8 +250,7 @@ if test "$have_bsd" = "yes"; then
    AC_DEFINE(HAVE_LIBBSD, 1, [Define if libbsd is available])
 fi
 
-
-PKG_CHECK_MODULES([LIBYAMI], [libyami >= 0.5.2])
+PKG_CHECK_MODULES([LIBYAMI], [libyami >= 0.5.5])
 
 # Checks for library functions.
 AC_FUNC_MALLOC

--- a/tests/decodeinputavformat.cpp
+++ b/tests/decodeinputavformat.cpp
@@ -144,6 +144,7 @@ bool DecodeInputAvFormat::getNextDecodeUnit(VideoDecodeBuffer &inputBuffer)
             inputBuffer.data = m_packet.data;
             inputBuffer.size = m_packet.size;
             inputBuffer.timeStamp = m_packet.dts;
+            inputBuffer.flag = VIDEO_DECODE_BUFFER_FLAG_FRAME_END;
             return true;
         }
     }


### PR DESCRIPTION
If we know we got a entire frame, we can pass the flag to decoder to tell them stop search for next frame. this need work with https://github.com/intel/libyami/pull/849