### PR TITLE
Add flags for SDL signoff called SDL325 - Compile With Defenses Enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -170,8 +170,12 @@ AC_ARG_ENABLE(oclblender,
 AM_CONDITIONAL(BUILD_OCL_BLENDER,
     [test "x$enable_oclblender" = "xyes"])
 
-AC_SUBST([AM_CFLAGS], ["-g -O2 -Wall -Wno-unused-function -Wno-cpp -Werror"])
-AC_SUBST([AM_CXXFLAGS], ["-g -O2 -Wall -Wno-unused-function -Wno-cpp -Wno-missing-braces -Werror"])
+AC_SUBST([AM_CFLAGS], ["-g -O2 -fPIE -fPIC -fstack-protector -Wall -Wno-unused-function -Wno-cpp -Werror"])
+AC_SUBST([AM_CXXFLAGS], ["-g -O2 -fPIE -fPIC -fstack-protector -Wall -Wno-unused-function -Wno-cpp -Wno-missing-braces -Werror"])
+
+#Add flags for SDL signoff called SDL325 - Compile With Defenses Enabled
+AC_SUBST([AM_CPPFLAGS], ["-D_FORTIFY_SOURCE=2"])
+AC_SUBST([AM_LDFLAGS], ["-z noexecstack -z relro -z now"])
 
 # Checks for programs.
 AC_DISABLE_STATIC

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -18,7 +18,7 @@ extra_includes = \
         -I$(top_srcdir) \
         $(NULL)
 
-AM_CFLAGS = \
+YAMI_COMMON_CFLAGS = \
 	-I../tests \
 	$(LIBYAMI_CFLAGS) \
 	$(LIBVA_CFLAGS) \
@@ -31,7 +31,7 @@ DECODE_INPUT_SOURCES = \
 
 if ENABLE_AVFORMAT
 DECODE_INPUT_SOURCES += ../tests/decodeinputavformat.cpp
-AM_CFLAGS += -D__STDC_CONSTANT_MACROS \
+YAMI_COMMON_CFLAGS += -D__STDC_CONSTANT_MACROS \
 	$(LIBAVFORMAT_CFLAGS)
 endif
 
@@ -45,7 +45,6 @@ VPP_INPUT_SOURCES = \
 	../tests/encodeInputCamera.cpp \
 	$(NULL)
 
-AM_CPPFLAGS = $(AM_CFLAGS)
 YAMI_COMMON_LIBS = \
 	$(LIBVA_LIBS) \
 	$(LIBVA_DRM_LIBS) \
@@ -83,18 +82,17 @@ VPP_INPUT_CFLAGS = \
 
 if ENABLE_X11
 simpleplayer_LDADD = $(YAMI_DECODE_LIBS)
-simpleplayer_LDFLAGS = $(LIBYAMI_CFLAGS)
+simpleplayer_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 simpleplayer_SOURCES = simpleplayer.cpp $(DECODE_INPUT_SOURCES)
 
 blend_LDADD = $(VPP_INPUT_LIBS) -lpthread
-blend_LDFLAGS = $(VPP_INPUT_LDFLAGS) $(LIBYAMI_CFLAGS)
+blend_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 blend_SOURCES	= blend.cpp $(VPP_INPUT_SOURCES)
 endif
 
 if ENABLE_DMABUF
 grid_LDADD = $(VPP_INPUT_LIBS) $(LIBDRM_LIBS) -lpthread
-grid_CPPFLAGS = $(LIBYAMI_CFLAGS) $(LIBDRM_CFLAGS) $(AM_CPPFLAGS)
-grid_LDFLAGS = $(VPP_INPUT_LDFLAGS) $(LIBYAMI_CFLAGS) $(LIBDRM_CFLAGS)
+grid_CPPFLAGS = $(LIBDRM_CFLAGS) $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 grid_SOURCES = grid.cpp $(VPP_INPUT_SOURCES)
 endif
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,7 +8,7 @@ extra_includes = \
         -I$(top_srcdir) \
         $(NULL)
 
-AM_CFLAGS = \
+YAMI_COMMON_CFLAGS = \
 	$(LIBVA_CFLAGS) \
 	$(LIBYAMI_CFLAGS) \
 	$(extra_includes) \
@@ -29,7 +29,7 @@ YAMI_DECODE_LIBS = \
 	$(NULL)
 
 if ENABLE_V4L2
-AM_CFLAGS += \
+YAMI_COMMON_CFLAGS += \
 	$(LIBYAMIV4L2_CFLAGS) \
 	$(NULL)
 
@@ -40,12 +40,10 @@ endif
 
 if ENABLE_AVFORMAT
 DECODE_INPUT_SOURCES += decodeinputavformat.cpp
-AM_CFLAGS += -D__STDC_CONSTANT_MACROS \
+YAMI_COMMON_CFLAGS += -D__STDC_CONSTANT_MACROS \
 	$(LIBAVFORMAT_CFLAGS)
 YAMI_DECODE_LIBS += $(LIBAVFORMAT_LIBS)
 endif
-
-AM_CPPFLAGS = $(AM_CFLAGS)
 
 if ENABLE_X11
 YAMI_COMMON_LIBS += $(LIBVA_X11_LIBS) -lX11
@@ -94,18 +92,18 @@ YAMI_VPP_CFLAGS = \
 	$(NULL)
 
 yamidecode_LDADD    = $(YAMI_VPP_LIBS)
-yamidecode_LDFLAGS  = $(YAMI_VPP_LDFLAGS)
+yamidecode_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 yamidecode_SOURCES  = decode.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES) decodeoutput.cpp vppinputoutput.cpp vppinputdecode.cpp vppoutputencode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp vppinputdecodecapi.cpp md5.c
 if ENABLE_EGL
 yamidecode_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
 endif
 
 yamiencode_LDADD    = $(YAMI_ENCODE_LIBS)
-yamiencode_LDFLAGS  = $(YAMI_ENCODE_LDFLAGS)
+yamiencode_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 yamiencode_SOURCES  = encode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES)
 
 v4l2decode_LDADD   = $(V4L2_DECODE_LIBS)
-v4l2decode_LDFLAGS = $(V4L2_DECODE_LDFLAGS)
+v4l2decode_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 v4l2decode_SOURCES = v4l2decode.cpp V4L2Renderer.cpp V4L2Device.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES)
 
 if ENABLE_EGL
@@ -115,20 +113,22 @@ v4l2decode_LDADD += -ldl
 
 
 v4l2encode_LDADD   = $(V4L2_ENCODE_LIBS)
-v4l2encode_LDFLAGS = $(V4L2_ENCODE_LDFLAGS)
+v4l2encode_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 v4l2encode_SOURCES = v4l2encode.cpp encodeinput.h encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES)
 
 yamivpp_LDADD    = $(YAMI_VPP_LIBS)
-yamivpp_LDFLAGS  = $(YAMI_VPP_LDFLAGS)
+yamivpp_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 yamivpp_SOURCES  = vppinputdecode.cpp vppinputoutput.cpp vppoutputencode.cpp  vpp.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES) vppinputdecodecapi.cpp
 
 yamitranscode_LDADD    = $(YAMI_VPP_LIBS)
-yamitranscode_LDFLAGS  = -pthread $(YAMI_VPP_LDFLAGS)
+yamitranscode_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
+yamitranscode_LDFLAGS  = -pthread $(AM_LDFLAGS)
 yamitranscode_SOURCES  = vppinputdecode.cpp vppinputoutput.cpp vppoutputencode.cpp  yamitranscode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES) vppinputasync.cpp vppinputdecodecapi.cpp 
 
 bin_PROGRAMS += yamiinfo
 yamiinfo_SOURCES = yamiinfo.cpp
+yamiinfo_CPPFLAGS = $(YAMI_COMMON_CFLAGS) $(AM_CPPFLAGS)
 yamiinfo_LDADD = $(YAMI_COMMON_LIBS)
 yamiinfo_LDFLAGS = -Wl,--no-as-needed \
-	$(LIBYAMI_CFLAGS) \
+	$(AM_LDFLAGS) \
 	$(NULL)


### PR DESCRIPTION
Due to the flags SDL required for Linux again, we need add these flags for SDL signoff called SDL325 - Compile With Defenses Enabled