### PR TITLE
Properly initialize VideoDecodeBuffer

### DIFF
--- a/examples/androidplayer.cpp
+++ b/examples/androidplayer.cpp
@@ -141,6 +141,8 @@ public:
         assert(status == DECODE_SUCCESS);
 
         VideoDecodeBuffer inputBuffer;
+        memset(&inputBuffer, 0, sizeof(inputBuffer));
+
         while (m_input->getNextDecodeUnit(inputBuffer)) {
             status = m_decoder->decode(&inputBuffer);
             if (DECODE_FORMAT_CHANGE == status) {

--- a/examples/simpleplayer.cpp
+++ b/examples/simpleplayer.cpp
@@ -74,6 +74,8 @@ public:
         assert(status == DECODE_SUCCESS);
 
         VideoDecodeBuffer inputBuffer;
+        memset(&inputBuffer, 0, sizeof(inputBuffer));
+
         while (m_input->getNextDecodeUnit(inputBuffer)) {
             status = m_decoder->decode(&inputBuffer);
             if (DECODE_FORMAT_CHANGE == status) {

--- a/tests/decodecapi.c
+++ b/tests/decodecapi.c
@@ -40,6 +40,8 @@ int main(int argc, char** argv)
     const VideoFormatInfo *formatInfo = NULL;
     Decode_Status status;
 
+    memset(&inputBuffer, 0, sizeof(inputBuffer));
+
     if (!process_cmdline(argc, argv))
         return -1;
 

--- a/tests/encodeInputDecoder.cpp
+++ b/tests/encodeInputDecoder.cpp
@@ -64,7 +64,10 @@ bool EncodeInputDecoder::decodeOneFrame()
 {
     if (!m_input || !m_decoder)
         return false;
+
     VideoDecodeBuffer inputBuffer;
+    memset(&inputBuffer, 0, sizeof(inputBuffer));
+
     if (!m_input->getNextDecodeUnit(inputBuffer)) {
         memset(&inputBuffer, 0, sizeof(inputBuffer));
         //flush decoder

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -81,6 +81,7 @@ bool feedOneInputFrame(const SharedPtr<DecodeInput>& input, const SharedPtr<V4L2
     struct v4l2_plane planes[k_inputPlaneCount];
     int ioctlRet = -1;
 
+    memset(&inputBuffer, 0, sizeof(inputBuffer));
     memset(&buf, 0, sizeof(buf));
     memset(&planes, 0, sizeof(planes));
     buf.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE; // it indicates input buffer(raw frame) type

--- a/tests/vppinputdecode.cpp
+++ b/tests/vppinputdecode.cpp
@@ -67,7 +67,10 @@ bool VppInputDecode::read(SharedPtr<VideoFrame>& frame)
             return true;
         if (m_error || m_eos)
             return false;
+
         VideoDecodeBuffer inputBuffer;
+        memset(&inputBuffer, 0, sizeof(inputBuffer));
+
         Decode_Status status = DECODE_FAIL;
         if (m_input->getNextDecodeUnit(inputBuffer)) {
             status = m_decoder->decode(&inputBuffer);

--- a/tests/vppinputdecodecapi.cpp
+++ b/tests/vppinputdecodecapi.cpp
@@ -72,7 +72,10 @@ bool VppInputDecodeCapi::read(SharedPtr<VideoFrame>& frame)
         }
         if (m_error || m_eos)
             return false;
+
         VideoDecodeBuffer inputBuffer;
+        memset(&inputBuffer, 0, sizeof(inputBuffer));
+
         Decode_Status status = DECODE_FAIL;
         if (m_input->getNextDecodeUnit(inputBuffer)) {
             status = decodeDecode(m_decoder, &inputBuffer);


### PR DESCRIPTION
libyami introduced VIDEO_DECODE_BUFFER_FLAG_FRAME_END and
uses it in avc/hevc decoder to stop frame decoding in
some cases.  Thus, it is necessary to properly initialize
the VideoDecodeBuffer so that VIDEO_DECODE_BUFFER_FLAG_FRAME_END
is not erroneously and arbitrarily set.

Fixes #134

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>